### PR TITLE
Fix empty descriptions for datastorage link operation adds

### DIFF
--- a/src/services/dataStorages/model_crud/dataStorages_model_crud_v2_svc.py
+++ b/src/services/dataStorages/model_crud/dataStorages_model_crud_v2_svc.py
@@ -18,6 +18,8 @@ class DataStoragesModelCRUDV2(DataStoragesModelCRUD):
     - операции привязки интеграционного тега как дочерние LDAP-узлы linkedTags[].operations
     """
 
+    _empty_optional_add_attrs = {"description"}
+
     async def _further_read(self, mes: dict, search_result: dict) -> dict:
         res = await super()._further_read(mes, search_result)
 
@@ -365,6 +367,18 @@ class DataStoragesModelCRUDV2(DataStoragesModelCRUD):
         vals["objectClass"] = [object_class]
         return vals
 
+    def _prepare_node_add_attrs(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        vals = copy.deepcopy(attrs or {})
+        for key in self._empty_optional_add_attrs:
+            value = vals.get(key)
+            if value is None or (isinstance(value, str) and not value):
+                vals.pop(key, None)
+            elif isinstance(value, list) and all(
+                item is None or (isinstance(item, str) and not item) for item in value
+            ):
+                vals.pop(key, None)
+        return vals
+
     def _ldap_attrs_to_payload(self, attrs: dict[str, Any]) -> dict[str, Any]:
         result: dict[str, Any] = {}
         for key, raw in attrs.items():
@@ -434,7 +448,7 @@ class DataStoragesModelCRUDV2(DataStoragesModelCRUD):
             if not existed:
                 op_id = await self._hierarchy.add(
                     base=link_id,
-                    attribute_values=node_attrs,
+                    attribute_values=self._prepare_node_add_attrs(node_attrs),
                 )
             else:
                 op_id = existed[0]
@@ -493,7 +507,7 @@ class DataStoragesModelCRUDV2(DataStoragesModelCRUD):
             if not existed:
                 await self._hierarchy.add(
                     base=op_id,
-                    attribute_values=node_attrs,
+                    attribute_values=self._prepare_node_add_attrs(node_attrs),
                 )
             else:
                 modify_attrs = dict(node_attrs)

--- a/tests/unit/integrational_link_operations_contract.py
+++ b/tests/unit/integrational_link_operations_contract.py
@@ -275,6 +275,7 @@ def test_v2_sync_link_operations_keeps_extra_attrs_and_nested_parameters():
     dummy._hierarchy = types.SimpleNamespace(search=_search, add=_add, modify=_modify, delete=_delete)
     dummy._attrs_dict = types.MethodType(DataStoragesModelCRUDV2._attrs_dict, dummy)
     dummy._prepare_node_attrs = types.MethodType(DataStoragesModelCRUDV2._prepare_node_attrs, dummy)
+    dummy._prepare_node_add_attrs = types.MethodType(DataStoragesModelCRUDV2._prepare_node_add_attrs, dummy)
     dummy._sync_link_operation_parameters = types.MethodType(
         DataStoragesModelCRUDV2._sync_link_operation_parameters, dummy
     )
@@ -314,6 +315,80 @@ def test_v2_sync_link_operations_keeps_extra_attrs_and_nested_parameters():
     assert "parameters" not in op_add[1]
     assert p_add[1]["cn"] == "start"
     assert p_add[1]["description"] == "Shift start"
+
+
+def test_v2_sync_link_operations_omits_empty_description_on_new_nodes():
+    dummy = types.SimpleNamespace()
+    added: list[tuple[str, dict]] = []
+
+    async def _search(payload: dict):
+        flt = payload.get("filter") or {}
+        obj = (flt.get("objectClass") or [None])[0]
+        if obj in ("prsDatastorageTagOperation", "prsDatastorageTagOperationParameter"):
+            return []
+        return []
+
+    async def _add(base: str, attribute_values: dict):
+        added.append((base, attribute_values))
+        if attribute_values.get("objectClass") == ["prsDatastorageTagOperation"]:
+            return "op-node-1"
+        return f"param-node-{attribute_values['cn']}"
+
+    async def _modify(_id: str, _attrs: dict):
+        return None
+
+    async def _delete(_id: str):
+        return None
+
+    dummy._hierarchy = types.SimpleNamespace(search=_search, add=_add, modify=_modify, delete=_delete)
+    dummy._attrs_dict = types.MethodType(DataStoragesModelCRUDV2._attrs_dict, dummy)
+    dummy._prepare_node_attrs = types.MethodType(DataStoragesModelCRUDV2._prepare_node_attrs, dummy)
+    dummy._prepare_node_add_attrs = types.MethodType(DataStoragesModelCRUDV2._prepare_node_add_attrs, dummy)
+    dummy._sync_link_operation_parameters = types.MethodType(
+        DataStoragesModelCRUDV2._sync_link_operation_parameters, dummy
+    )
+
+    asyncio.run(
+        DataStoragesModelCRUDV2._sync_link_operations(
+            dummy,
+            link_id="link-1",
+            operations=[
+                {
+                    "attributes": {
+                        "cn": "products.update.v1",
+                        "prsActive": True,
+                        "prsEntityTypeCode": 1,
+                        "description": "",
+                        "prsJsonConfigString": {
+                            "query": "update products set sku = :new_sku where sku = :sku",
+                        },
+                    },
+                    "parameters": [
+                        {
+                            "attributes": {
+                                "cn": "new_sku",
+                                "prsActive": True,
+                                "description": "",
+                                "prsJsonConfigString": {"JSONata": "$.params.new_sku"},
+                            }
+                        },
+                        {
+                            "attributes": {
+                                "cn": "sku",
+                                "prsActive": True,
+                                "description": None,
+                                "prsJsonConfigString": {"JSONata": "$.params.sku"},
+                            }
+                        },
+                    ],
+                }
+            ],
+            replace=True,
+        )
+    )
+
+    for _, attrs in added:
+        assert "description" not in attrs
 
 
 def test_v2_read_tag_link_operations_returns_extra_attrs():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- omit empty optional `description` attributes when creating v2 datastorage link operation LDAP nodes
- keep non-empty descriptions and existing modify semantics intact
- add regression coverage for new operations/parameters with empty or null descriptions

## Tests
- Not run yet (pre-testing revision per Cloud Agent workflow).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a8ebfed-c07d-4ccc-b8d0-813b02fb14ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a8ebfed-c07d-4ccc-b8d0-813b02fb14ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

