### PR TITLE
Set Grafana default language to Russian

### DIFF
--- a/docker/docker-files/grafana/Dockerfile.grafana
+++ b/docker/docker-files/grafana/Dockerfile.grafana
@@ -3,6 +3,8 @@ FROM grafana/grafana-enterprise:12.4.0-22081664032-ubuntu
 #EXPOSE 3000
 ARG NGINX_HOST
 
+ENV GF_USERS_DEFAULT_LANGUAGE=ru-RU
+
 USER root
 
 RUN mkdir /var/lib/grafana/dashboards


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set `GF_USERS_DEFAULT_LANGUAGE=ru-RU` in the Grafana Dockerfile so built images default to Russian UI language.

## Validation
- Verified statically that `docker/docker-files/grafana/Dockerfile.grafana` contains `ENV GF_USERS_DEFAULT_LANGUAGE=ru-RU`.
- Docker compose/build validation was not run because `docker` is not installed in the Cloud Agent environment (`docker: command not found`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c84d7430-dee0-4005-82df-d29abb4d6334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c84d7430-dee0-4005-82df-d29abb4d6334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

